### PR TITLE
[FEAT] : 게임 방법 플로우 및 화면 생성 + 오버플로우 해결

### DIFF
--- a/lib/controllers/check_decibel_page.controller.dart
+++ b/lib/controllers/check_decibel_page.controller.dart
@@ -15,6 +15,9 @@ class CheckDecibelPageController extends GetxController{
  late StreamSubscription<NoiseReading> _noiseCheck;
  Timer? _changeTextTimer;
 
+ // getter 추가
+ String get initialText => _initialText;
+
    // 초기 텍스트만 설정
   void setInitialText(String text) {
     _initialText = text;
@@ -29,7 +32,7 @@ class CheckDecibelPageController extends GetxController{
          overDecibel.value += 1;
          if (overDecibel.value >= 3) {
            stopCheck();
-           Get.to(() => LoadingPrepareScreen());
+           Get.to(() => LoadingPrepareScreen(gameMode: _initialText));
          }
        }
      },

--- a/lib/controllers/check_decibel_page.controller.dart
+++ b/lib/controllers/check_decibel_page.controller.dart
@@ -8,10 +8,18 @@ import '../views/loading/loading_prepare_screen.dart';
 
 class CheckDecibelPageController extends GetxController{
  Rx<int> overDecibel = 0.obs;
- Rx<String> displayedText = '사용하시는 악기를 여러번 연주해주세요!'.obs;
+ Rx<String> displayedText = ''.obs;
+
+ String _initialText = '';
 
  late StreamSubscription<NoiseReading> _noiseCheck;
  Timer? _changeTextTimer;
+
+   // 초기 텍스트만 설정
+  void setInitialText(String text) {
+    _initialText = text;
+    displayedText.value = text;
+  }
 
  void checkDecibel() {
    _noiseCheck = NoiseMeter().noise.listen(
@@ -39,7 +47,7 @@ class CheckDecibelPageController extends GetxController{
  }
 
  void stopCheck() {
-   displayedText.value = '사용하시는 악기를 여러번 연주해주세요!';
+   displayedText.value = _initialText;
    overDecibel.value = 0;
    _changeTextTimer?.cancel();
    _noiseCheck.cancel();

--- a/lib/views/check/check_decibel_screen.dart
+++ b/lib/views/check/check_decibel_screen.dart
@@ -20,6 +20,8 @@ class _CheckDecibelScreenState extends State<CheckDecibelScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       controller.checkDecibel();
       controller.changeText();
+      controller.setInitialText('사용하시는 악기를 여러번 연주해주세요!');
+
     });
   }
 

--- a/lib/views/home/home_button.dart
+++ b/lib/views/home/home_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:sanhak/views/rule/rule_step1_screen.dart';
 
 import 'instrument_screen.dart';
 
@@ -24,9 +25,14 @@ class HomeButton extends StatelessWidget {
             Get.to(() => InstrumentScreen());
           },
         ),
-        Image.asset(
-          'assets/images/buttons/게임방법.png',
-          width: 192,
+        GestureDetector(
+          child: Image.asset(
+            'assets/images/buttons/게임방법.png',
+            width: 192,
+          ),
+          onTap: () {
+            Get.to(() => RuleStep1Screen());
+          },
         ),
       ],
     );

--- a/lib/views/home/music_button.dart
+++ b/lib/views/home/music_button.dart
@@ -13,7 +13,7 @@ class MusicButton extends StatefulWidget {
 
 class _MusicButtonState extends State<MusicButton> {
   final PageController _pageController = PageController(
-    viewportFraction: 0.3,
+    viewportFraction: 0.35,
     initialPage: 1,
   );
   
@@ -35,7 +35,7 @@ class _MusicButtonState extends State<MusicButton> {
     return Column(
       children: [
         SizedBox(
-          height: height * 0.57,
+          height: height * 0.55,
           child: PageView.builder(
             controller: _pageController,
             onPageChanged: (index) {

--- a/lib/views/loading/loading_prepare_screen.dart
+++ b/lib/views/loading/loading_prepare_screen.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import '../../controllers/game_screen_controller.dart';
 import '../../provider.dart';
 import '../game/game_screen.dart';
+import '../rule/rule_game_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,8 +31,9 @@ class LoadingPrepareScreenApp extends StatelessWidget {
 }
 
 class LoadingPrepareScreen extends StatefulWidget {
-  const LoadingPrepareScreen({super.key});
-
+  final String? gameMode; // 게임 모드 매개변수 (rule 화면 or gmae 화면 결정)
+  
+  const LoadingPrepareScreen({super.key, this.gameMode});
   @override
   State<LoadingPrepareScreen> createState() => _LoadingPrepareScreenState();
 }
@@ -42,8 +44,13 @@ class _LoadingPrepareScreenState extends State<LoadingPrepareScreen> {
   Future<void> _prepareInformation() async {
     await controller.fetchMeasures();
     await Future.delayed(const Duration(seconds: 3));
-    Get.to(() => GameScreen());
-  }
+    // gameMode에 따라 분기
+    // 이후 gamefinal 등 다른 화면으로 전환을 위한 수정 필요
+    if (widget.gameMode == '게임을 시작하기 전, 음향테스트를 진행합니다.\n사용하시는 악기를 여러번 연주해주세요!') {
+      Get.to(() => RuleGameScreen());
+    } else {
+      Get.to(() => GameScreen());
+    }  }
 
   @override
   void initState() {

--- a/lib/views/rule/rule_bottom_button.dart
+++ b/lib/views/rule/rule_bottom_button.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import '../../components/buttons/exit_dialog.dart';
+
+
+
+class RuleBottomButton extends StatelessWidget {
+  const RuleBottomButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+          onTap: () {
+            exitDialog();
+          },
+          child: Image.asset(
+            'assets/images/buttons/나가기.png',
+            width: 88,
+          ),
+        );
+  }
+}

--- a/lib/views/rule/rule_check_decibel_screen.dart
+++ b/lib/views/rule/rule_check_decibel_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:sanhak/controllers/check_decibel_page.controller.dart';
+import 'package:sanhak/views/rule/rule_bottom_button.dart';
+class RuleCheckDecibelScreen extends StatefulWidget {
+  const RuleCheckDecibelScreen({super.key});
+
+  @override
+  State<RuleCheckDecibelScreen> createState() => _RuleCheckDecibelScreenState();
+}
+
+class _RuleCheckDecibelScreenState extends State<RuleCheckDecibelScreen> {
+  final controller = Get.find<CheckDecibelPageController>();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.checkDecibel();
+      controller.changeText();
+    });
+  }
+
+  @override
+  void dispose() {
+    controller.stopCheck();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: Image.asset('assets/images/background/배경화면2.png', fit: BoxFit.cover),
+          ),
+          const Positioned(
+            top: 15,
+            left: 20,
+            child: Text(
+              '게임 방법',
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 20,
+                color: Color(0xFFEDEAE6),
+              ),
+            ),
+          ),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Obx(() => Text(
+                      controller.displayedText.value,
+                      style: TextStyle(color: Colors.black, fontSize: 30),
+                    ),
+                  ),
+                  SizedBox(height: 20,),
+                  Image.asset('assets/images/icons/스피커.png', width: 40,),
+                ],
+              ),
+            ),
+          Positioned(
+            bottom: 9,
+            left: 70,
+            child: RuleBottomButton(),
+          ),   
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/rule/rule_check_decibel_screen.dart
+++ b/lib/views/rule/rule_check_decibel_screen.dart
@@ -18,6 +18,9 @@ class _RuleCheckDecibelScreenState extends State<RuleCheckDecibelScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       controller.checkDecibel();
       controller.changeText();
+      controller.setInitialText(
+        '게임을 시작하기 전, 음향테스트를 진행합니다.\n사용하시는 악기를 여러번 연주해주세요!',
+      );
     });
   }
 

--- a/lib/views/rule/rule_final_screen.dart
+++ b/lib/views/rule/rule_final_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:sanhak/views/home/home_screen.dart';
+import 'package:sanhak/views/rule/rule_bottom_button.dart';
+
+class RuleFinalScreen extends StatefulWidget {
+  const RuleFinalScreen({super.key});
+
+  @override
+  State<RuleFinalScreen> createState() => _RuleFinalScreenState();
+}
+
+class _RuleFinalScreenState extends State<RuleFinalScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // 2초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 2), () {
+      Get.to(() => HomeScreen());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.asset(
+            'assets/images/background/배경화면2.png',
+            fit: BoxFit.cover,
+          ),
+
+          const Positioned(
+            top: 15,
+            left: 20,
+            child: Text(
+              '게임 방법',
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 20,
+                color: Color(0xFFEDEAE6),
+              ),
+            ),
+          ),
+
+          const Center(
+            child: Text(
+              '고생하셨습니다!\n이제 본격적인 사물놀이 연주를 시작해볼까요?',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 24,
+                color: Color(0xFF2C3342),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 9,
+            left: 70,
+            child: RuleBottomButton(),
+          ),        
+          ],
+      ),
+    ); 
+  }
+}

--- a/lib/views/rule/rule_final_screen.dart
+++ b/lib/views/rule/rule_final_screen.dart
@@ -17,8 +17,8 @@ class _RuleFinalScreenState extends State<RuleFinalScreen> {
   void initState() {
     super.initState();
     
-    // 2초 후 다음 화면으로 전환
-    Future.delayed(const Duration(seconds: 2), () {
+    // 3초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 3), () {
       Get.to(() => HomeScreen());
     });
   }

--- a/lib/views/rule/rule_game_screen.dart
+++ b/lib/views/rule/rule_game_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:sanhak/views/rule/rule_final_screen.dart';
+
+import '../../components/appbars/appbar_with_percent_bar.dart';
+import 'package:sanhak/views/rule/rule_bottom_button.dart';
+import '../../components/icons/drums_with_name.dart';
+import '../../controllers/game_screen_controller.dart';
+
+class RuleGameScreen extends StatefulWidget {
+  const RuleGameScreen({super.key});
+
+  @override
+  State<RuleGameScreen> createState() => _RuleGameScreenState();
+}
+
+class _RuleGameScreenState extends State<RuleGameScreen> {
+  final List<bool> _isBig = List.generate(8, (_) => false);
+  final controller = Get.find<GameScreenController>();
+
+  Future<void> _startSequentialAnimation() async {
+    for (int j = 0; j < controller.totalMeasure.value; j++) {
+      for (int i = 0; i < _isBig.length; i++) {
+        setState(() {
+          _isBig[i] = true;
+        });
+        await Future.delayed(const Duration(milliseconds: 200));
+
+        setState(() {
+          _isBig[i] = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    ever(controller.currentMeasure, (value) {
+      if (value.length != 8) {
+        Future.delayed(const Duration(seconds: 5), () {
+          Get.to(() => const RuleFinalScreen());
+        });
+      }
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Future.delayed(const Duration(seconds: 3));
+      controller.updateMeasures();
+      _startSequentialAnimation();
+    });
+  }
+
+  @override
+  void dispose() {
+    controller.controllerDispose();
+    // 만약 애니메이션을 추가할 경우 dispose 필요
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Image.asset(
+              'assets/images/background/배경화면2.png',
+              fit: BoxFit.cover
+          ),
+        ),
+        Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBarWithPercentBar(),
+          body: Stack( // Column을 Stack으로 변경
+            children: [
+              Column(
+                children: [
+                  Expanded(
+                    child: (controller.currentMeasure.value.length == 8)
+                     ? Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: List.generate(8, (i) {
+                            return controller.currentMeasure.value.length > i && controller.currentMeasure.value[i].isNotEmpty
+                                ? Transform.scale(
+                              scale: _isBig[i] ? 1.5 : 1.0,
+                              child: IconWithName(name: controller.currentMeasure.value[i],),
+                            )
+                                : const SizedBox(width: 100,);
+                          }),
+                        ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: controller.nextMeasure.value.length == 8
+                              ? List.generate(8, (i) {
+                            return controller.nextMeasure.value[i].isNotEmpty
+                                ? IconWithName(name: controller.nextMeasure.value[i])
+                                : const SizedBox(width: 100);
+                          })
+                              : [const SizedBox(height: 100,)],
+                        ),
+                      ],
+                    )
+                        : Center(child: Text(
+                        '연주를 완료하였습니다!',
+                      style: TextStyle(
+                        fontSize: 30,
+                      ),
+                    )),
+                  ),
+                ],
+              ),
+              Positioned(
+                bottom: 9,
+                left: 70,
+                child: RuleBottomButton(),
+              ),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/views/rule/rule_step1_screen.dart
+++ b/lib/views/rule/rule_step1_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:sanhak/views/rule/rule_bottom_button.dart';
+import 'package:sanhak/views/rule/rule_step2_screen.dart';
+
+
+class RuleStep1Screen extends StatefulWidget {
+  const RuleStep1Screen({super.key});
+
+  @override
+  State<RuleStep1Screen> createState() => _RuleStep1ScreenState();
+}
+
+class _RuleStep1ScreenState extends State<RuleStep1Screen> {
+  
+  @override
+  void initState() {
+    super.initState();
+    
+    // 3초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 3), () {
+      Get.to(() => RuleStep2Screen());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.asset(
+            'assets/images/background/배경화면2.png',
+            fit: BoxFit.cover,
+          ),
+
+          const Positioned(
+            top: 15,
+            left: 20,
+            child: Text(
+              '게임 방법',
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 20,
+                color: Color(0xFFEDEAE6),
+              ),
+            ),
+          ),
+
+          const Center(
+            child: Text(
+              '연주를 시작하기 전 사용하는 악기와\n 연주하고 싶은 음악을 고를 수 있습니다.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 24,
+                color: Color(0xFF2C3342),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 9,
+            left: 70,
+            child: RuleBottomButton(),
+          ),        
+          ],
+      ),
+    );  }
+}

--- a/lib/views/rule/rule_step1_screen.dart
+++ b/lib/views/rule/rule_step1_screen.dart
@@ -18,8 +18,8 @@ class _RuleStep1ScreenState extends State<RuleStep1Screen> {
   void initState() {
     super.initState();
     
-    // 3초 후 다음 화면으로 전환
-    Future.delayed(const Duration(seconds: 3), () {
+    // 2초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 2), () {
       Get.to(() => RuleStep2Screen());
     });
   }
@@ -66,5 +66,6 @@ class _RuleStep1ScreenState extends State<RuleStep1Screen> {
           ),        
           ],
       ),
-    );  }
+    );  
+  }
 }

--- a/lib/views/rule/rule_step2_screen.dart
+++ b/lib/views/rule/rule_step2_screen.dart
@@ -17,8 +17,8 @@ class _RuleStep2ScreenState extends State<RuleStep2Screen> {
   void initState() {
     super.initState();
     
-    // 3초 후 다음 화면으로 전환
-    Future.delayed(const Duration(seconds: 3), () {
+    // 2초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 2), () {
       Get.to(() => RuleCheckDecibelScreen());
     });
   }

--- a/lib/views/rule/rule_step2_screen.dart
+++ b/lib/views/rule/rule_step2_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:sanhak/views/rule/rule_bottom_button.dart';
+import 'package:sanhak/views/rule/rule_check_decibel_screen.dart';
 
 
 class RuleStep2Screen extends StatefulWidget {
@@ -18,7 +19,7 @@ class _RuleStep2ScreenState extends State<RuleStep2Screen> {
     
     // 3초 후 다음 화면으로 전환
     Future.delayed(const Duration(seconds: 3), () {
-      Get.to(() => RuleStep2Screen());
+      Get.to(() => RuleCheckDecibelScreen());
     });
   }
 

--- a/lib/views/rule/rule_step2_screen.dart
+++ b/lib/views/rule/rule_step2_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:sanhak/views/rule/rule_bottom_button.dart';
+
+
+class RuleStep2Screen extends StatefulWidget {
+  const RuleStep2Screen({super.key});
+
+  @override
+  State<RuleStep2Screen> createState() => _RuleStep2ScreenState();
+}
+
+class _RuleStep2ScreenState extends State<RuleStep2Screen> {
+  @override
+  void initState() {
+    super.initState();
+    
+    // 3초 후 다음 화면으로 전환
+    Future.delayed(const Duration(seconds: 3), () {
+      Get.to(() => RuleStep2Screen());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.asset(
+            'assets/images/background/배경화면2.png',
+            fit: BoxFit.cover,
+          ),
+
+          const Positioned(
+            top: 15,
+            left: 20,
+            child: Text(
+              '게임 방법',
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 20,
+                color: Color(0xFFEDEAE6),
+              ),
+            ),
+          ),
+
+          const Center(
+            child: Text(
+              '사용하시는 악기를\n화면에 나오는 악보에 맞춰서\n연주하시면 됩니다!',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'SolmoeFont',
+                fontSize: 24,
+                color: Color(0xFF2C3342),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 9,
+            left: 70,
+            child: RuleBottomButton(),
+          ),  
+        ],
+      ),
+    );  }
+}


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
--> 

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 작업내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
##### 게임 방법 관련 화면 생성 및 연동
- 게임 방법 화면 1
- 게임 방법 화면 2
- 게임 방법 플레이
- 게임 방법 마무리

##### 음악 선택 페이지 오버플로우 해결

### 스크린샷 (선택)
<!--스크린샷을 남겨서 PR에 도움을 줄 수 있다면 스크린샷을 넣어주시는 것을 권장드립니다.-->
![1000027055](https://github.com/user-attachments/assets/52f2b465-6c6a-45fd-9b7a-b60ab4ae2cf5)
![1000027057](https://github.com/user-attachments/assets/b53792a0-6d8d-489b-b4b2-4954e4d7e52f)
![1000027059](https://github.com/user-attachments/assets/68ff781e-89c3-4553-a4ae-8804fab67018)
![1000027060](https://github.com/user-attachments/assets/60702d86-c3f1-4185-90cf-8c3e6accbfc4)

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 원래는 loading페이지에서 GameScreen 페이지로 넘어갈 수 있게 되어있길래 우선은 gameMode 관련 변수 전달로 로딩 이후 페이지를 gameScreen으로 할지, RuleGameScreen으로 할지 판단할 수 있도록만 해뒀습니다!
- 데시벨 체크 화면의 경우 _initialText를 다르게 설정해서 게임 방법, 게임 수행일 때 각각 text가 다르게 뜨도록 연동해뒀습니다!
- 음악 선택 화면 ) viewportfraction 값을 좀 바꿔서 overflow를 해결해뒀는데, 제 기기에서만 해결된 것처럼 보일 수도 있을 것 같아 확인 한번만 부탁드립니다!